### PR TITLE
GraphQL::Extras::PreloadDefault: preload associations by default

### DIFF
--- a/lib/graphql/extras/preload.rb
+++ b/lib/graphql/extras/preload.rb
@@ -29,5 +29,44 @@ module GraphQL
         super
       end
     end
+
+    module PreloadDefault
+      # @override
+      def initialize(*args, preload: nil, **opts, &block)
+        @preload = preload
+        if maybe_preload(opts[:type])
+          @preload_by_name = opts[:name]&.to_s
+        end
+        super(*args, **opts, &block)
+      end
+
+      # @override
+      def resolve(object, args, context)
+        if @preload == false
+          # nop
+        elsif @preload
+          loader = context.dataloader.with(PreloadSource, @preload)
+          loader.load(object.object)
+        elsif @preload_by_name && object.object.class.respond_to?(:reflections) && object.object.class.reflections.key?(@preload_by_name)
+          loader = context.dataloader.with(PreloadSource, @preload_by_name)
+          loader.load(object.object)
+        end
+
+        super
+      end
+
+      private
+
+      def maybe_preload(type)
+        (
+          type.is_a?(Array) &&
+          type.first.is_a?(Class) &&
+          type.first < GraphQL::Schema::Object
+        ) || (
+          type.is_a?(Class) &&
+          type < GraphQL::Schema::Object
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
In ActiveRecord, I think most of the time you use preload to read in the default relation name.
So I made a custom version of the module that calls preload if the preload option is not false.