### PR TITLE
fix: Fix duplication of fragment definitions in `Loader#print`

### DIFF
--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,4 +1,4 @@
-Copyright 2019-2022 Ray Zane
+Copyright 2019-2025 Ray Zane
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/lib/graphql/extras/test/loader.rb
+++ b/lib/graphql/extras/test/loader.rb
@@ -37,15 +37,17 @@ module GraphQL
         # Recursively iterate through the node's fields and find
         # resolve all of the fragment definitions that are needed.
         def resolve_fragments(node)
-          node.selections.flat_map do |field|
-            case field
+          result = node.selections.flat_map do |selection|
+            case selection
             when Nodes::FragmentSpread
-              fragment = fetch_fragment!(field.name)
+              fragment = fetch_fragment!(selection.name)
               [fragment, *resolve_fragments(fragment)]
             else
-              resolve_fragments(field)
+              resolve_fragments(selection)
             end
           end
+
+          result.uniq
         end
 
         def fetch_fragment!(name)

--- a/spec/fixtures/graphql/people.graphql
+++ b/spec/fixtures/graphql/people.graphql
@@ -2,4 +2,7 @@ query ListPeople {
   people {
     ...Person
   }
+  allPeople: people {
+    ...Person
+  }
 }

--- a/spec/graphql/extras/test/loader_spec.rb
+++ b/spec/graphql/extras/test/loader_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe GraphQL::Extras::Test::Loader do
     expect { loader.print(operation) }.to raise_error(Loader::FragmentNotFoundError)
   end
 
-  it "prints an operation, including fragments" do
+  it "prints an operation, including fragments, with no duplicates" do
     loader = Loader.new
     loader.load "spec/fixtures/graphql/person.graphql"
     loader.load "spec/fixtures/graphql/people.graphql"
@@ -38,6 +38,6 @@ RSpec.describe GraphQL::Extras::Test::Loader do
     graphql = loader.print(operation)
 
     expect(graphql).to include("query ListPeople")
-    expect(graphql).to include("fragment Person")
+    expect(graphql.scan("fragment Person").count).to eq 1
   end
 end


### PR DESCRIPTION
Found a bug where tests fail if a single fragment is used multiple times in the same document, because `graphql-extras` duplicates fragment definitions each time there's a new fragment spread, and `graphql-ruby` fails tests with a validation error when fragment names in a document are not unique. 

`Loader` is errantly duplicating fragments in its `print` method by adding a new fragment to the return value every time the document spreads on the fragment, so I'm updating the logic to just call `uniq` on the output of `resolve_fragments`. 

cc @rzane 